### PR TITLE
feat: 32056 remove desired task count from ecs patterns

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/ecs/queue-processing-ecs-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/ecs/queue-processing-ecs-service.ts
@@ -1,7 +1,5 @@
 import { Construct } from 'constructs';
 import { Ec2Service, Ec2TaskDefinition, PlacementConstraint, PlacementStrategy } from '../../../aws-ecs';
-import { FeatureFlags } from '../../../core';
-import * as cxapi from '../../../cx-api';
 import { QueueProcessingServiceBase, QueueProcessingServiceBaseProps } from '../base/queue-processing-service-base';
 
 /**
@@ -128,14 +126,10 @@ export class QueueProcessingEc2Service extends QueueProcessingServiceBase {
       logging: this.logDriver,
     });
 
-    // The desiredCount should be removed from the fargate service when the feature flag is removed.
-    const desiredCount = FeatureFlags.of(this).isEnabled(cxapi.ECS_REMOVE_DEFAULT_DESIRED_COUNT) ? undefined : this.desiredCount;
-
     // Create an ECS service with the previously defined Task Definition and configure
     // autoscaling based on cpu utilization and number of messages visible in the SQS queue.
     this.service = new Ec2Service(this, 'QueueProcessingService', {
       cluster: this.cluster,
-      desiredCount: desiredCount,
       taskDefinition: this.taskDefinition,
       serviceName: props.serviceName,
       minHealthyPercent: props.minHealthyPercent,

--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
@@ -1,8 +1,6 @@
 import { Construct } from 'constructs';
 import * as ec2 from '../../../aws-ec2';
 import { FargateService, FargateTaskDefinition, HealthCheck } from '../../../aws-ecs';
-import { FeatureFlags } from '../../../core';
-import * as cxapi from '../../../cx-api';
 import { FargateServiceBaseProps } from '../base/fargate-service-base';
 import { QueueProcessingServiceBase, QueueProcessingServiceBaseProps } from '../base/queue-processing-service-base';
 
@@ -95,14 +93,10 @@ export class QueueProcessingFargateService extends QueueProcessingServiceBase {
       throw new Error('You must specify one of: taskDefinition or image');
     }
 
-    // The desiredCount should be removed from the fargate service when the feature flag is removed.
-    const desiredCount = FeatureFlags.of(this).isEnabled(cxapi.ECS_REMOVE_DEFAULT_DESIRED_COUNT) ? undefined : this.desiredCount;
-
     // Create a Fargate service with the previously defined Task Definition and configure
     // autoscaling based on cpu utilization and number of messages visible in the SQS queue.
     this.service = new FargateService(this, 'QueueProcessingFargateService', {
       cluster: this.cluster,
-      desiredCount: desiredCount,
       taskDefinition: this.taskDefinition,
       serviceName: props.serviceName,
       minHealthyPercent: props.minHealthyPercent,

--- a/packages/aws-cdk-lib/aws-ecs-patterns/test/ec2/queue-processing-ecs-service.test.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/test/ec2/queue-processing-ecs-service.test.ts
@@ -352,30 +352,6 @@ testDeprecated('test ECS queue worker service construct - with optional props', 
   });
 });
 
-testDeprecated('throws if desiredTaskCount and maxScalingCapacity are 0', () => {
-  // GIVEN
-  const stack = new cdk.Stack();
-  const vpc = new ec2.Vpc(stack, 'VPC');
-  const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
-  cluster.addAsgCapacityProvider(new AsgCapacityProvider(stack, 'DefaultAutoScalingGroupProvider', {
-    autoScalingGroup: new AutoScalingGroup(stack, 'DefaultAutoScalingGroup', {
-      vpc,
-      instanceType: new ec2.InstanceType('t2.micro'),
-      machineImage: MachineImage.latestAmazonLinux(),
-    }),
-  }));
-
-  // THEN
-  expect(() =>
-    new ecsPatterns.QueueProcessingEc2Service(stack, 'Service', {
-      cluster,
-      desiredTaskCount: 0,
-      memoryLimitMiB: 512,
-      image: ecs.ContainerImage.fromRegistry('test'),
-    }),
-  ).toThrow(/maxScalingCapacity must be set and greater than 0 if desiredCount is 0/);
-});
-
 test('can set custom containerName', () => {
   // GIVEN
   const stack = new cdk.Stack();


### PR DESCRIPTION
### Issue # (if applicable)

Closes #32056 

### Reason for this change

desiredTaskCount is deprecated and not a property of the construct in use. Instead use of minCapacity and maxCapacity should be used. 

### Description of changes

Documentation specified that the user could use "desiredTaskCount " for the ecs-patterns construct. However "desiredTaskCount" is not a property of queueProcessingEc2Service, nor is desiredCount. Instead minCapacity and maxCapacity should be used to specify the count. 

### Description of how you validated changes

Updated unit tests, ran them, and created a successful build. 

### Checklist
- [ x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
